### PR TITLE
 シーケンス図で、創部申請と創部承認のエンドポイントを2回コールするよう修正

### DIFF
--- a/docs/sequence-diagram/CreateClub.pu
+++ b/docs/sequence-diagram/CreateClub.pu
@@ -23,6 +23,7 @@ alt 承認する場合
     auth -> slackapp: 承認用モーダルに表示された承認ボタンを押す
     slackapp --> sheet: シートの創部APIをコール(GAS)
     sheet -> sheet: 部活まとめタブの最終行に新規部活名をインサート
+    slackapp --> sheet: シートの承認APIをコール（GAS)
     sheet -> sheet: 新規部活タブを作成し内容を埋める
 
     opt シート創部APIコール失敗


### PR DESCRIPTION
close #101 
**_What I did / 技術的変更点概要_**
- CreateClub.puシーケンス図で、創部申請と創部承認のエンドポイントを2回コールするよう修正

**_Review Point / レビューしてほしい内容_**
- エラー処理をどうすべきか
    - 2回コールする場合、それぞれエラーが返ってくる可能性が有る
    - 2回ともエラー処理の記述をすべきかどうか

**_Test result & Test points / テスト結果とテスト項目_**

- [ ] ...
- [ ] ...

**_Additional context / 追記・備考_**

Add any other context about the problem here.
