### PR TITLE
承認機能結合(全部trueのケースのみ)

### DIFF
--- a/docs/sequence-diagram/CreateClub.pu
+++ b/docs/sequence-diagram/CreateClub.pu
@@ -19,7 +19,7 @@ sheet -> sheet: 部活まとめタブの最終行に新規部活名をインサ�
 
 break 創部APIコール失敗
     sheet -->> slackapp: エラーレスポンス
-    slackapp -->> captain: メッセージ「エラーが発生しました。開発者に連絡してください。」
+    slackapp -->> auth: メッセージ「エラーが発生しました。」
 end
 
 sheet -->> slackapp: 成功レスポンス
@@ -69,7 +69,7 @@ alt 承認する場合
 else 却下する場合
     auth -> slackapp: メッセージ内の却下ボタンを押す
     slackapp -> auth: 却下理由入力モーダルを表示
-    
+
     break キャンセルの場合
         auth -> slackapp: キャンセルボタンを押す
         slackapp -> auth: モーダルを閉じて処理を中断

--- a/src/api/gas/api.ts
+++ b/src/api/gas/api.ts
@@ -1,6 +1,6 @@
 import fetch from "node-fetch";
 import { URL } from "url";
-import { CallNewClubArg } from "../../types/Messages";
+import { CallNewClubArg, CallApproveClubArgs } from "../../types/Messages";
 import { Config } from "../../constant";
 import ResponseInterface from "../../gas/shared/types/ResponseInterface";
 
@@ -15,5 +15,25 @@ export const callNewClub = async (params: CallNewClubArg): Promise<ResponseInter
     body: JSON.stringify(params),
   });
 
+  return response.json();
+};
+
+export const callApproveClub = async ({
+  club: { channelId },
+  authorizer,
+}: CallApproveClubArgs): Promise<ResponseInterface> => {
+  const fullUrl = new URL(`${Config.Gas.END_POINT}?action=approve`);
+
+  const response = await fetch(fullUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      slackChannelId: channelId,
+      authorizer,
+      isApproved: true,
+    }),
+  });
   return response.json();
 };

--- a/src/api/kibela/mutations/note.ts
+++ b/src/api/kibela/mutations/note.ts
@@ -3,12 +3,12 @@ import { callAPI } from "../api";
 import type { Note } from "../../../../@types/kibela.d";
 import { fetchNoteByUrl } from "../queries/note";
 
-export const moveOfficialFolder = async (url: string, clubName: string): Promise<Note> => {
-  const note = await fetchNoteByUrl(url);
+export const moveOfficialFolder = async ({ kibelaUrl, name }: { kibelaUrl: string; name: string }): Promise<Note> => {
+  const note = await fetchNoteByUrl(kibelaUrl);
 
   const mutation = gql`
     mutation {
-      updateNoteFolder(input: { noteId: "${note.id}", folderFullName: "部活動/公認/${clubName}" }) {
+      updateNoteFolder(input: { noteId: "${note.id}", folderFullName: "部活動/公認/${name}" }) {
         note {
           id
           title

--- a/src/commands/newClub.ts
+++ b/src/commands/newClub.ts
@@ -43,11 +43,9 @@ export const useNewClubCommand = (app: App, approvalChannelId: string) => {
         state: { values },
       },
       client,
-      body,
     }) => {
       ack();
 
-      const postUserId = body.user.id;
       const memberIds = values.member_name.member.selected_users as string[];
       const members = await Promise.all(
         memberIds.map(async (slackId) => {
@@ -77,11 +75,9 @@ export const useNewClubCommand = (app: App, approvalChannelId: string) => {
       if (!response.success) {
         await client.chat
           .postMessage({
-            channel: postUserId,
+            channel: approvalChannelId,
             text: "エラーが発生しました",
-            blocks: [
-              sectionPlainText({ title: Club.Label.error, text: "エラーが発生しました。開発者に連絡してください" }),
-            ],
+            blocks: [sectionPlainText({ title: Club.Label.error, text: "エラーが発生しました。" })],
           })
           .catch((error) => {
             console.error({ error });
@@ -199,11 +195,9 @@ export const useNewClubCommand = (app: App, approvalChannelId: string) => {
       if (!response.success) {
         await client.chat
           .postMessage({
-            channel: authorizer.id,
+            channel: approvalChannelId,
             text: "エラーが発生しました",
-            blocks: [
-              sectionPlainText({ title: Club.Label.error, text: "エラーが発生しました。開発者に連絡してください" }),
-            ],
+            blocks: [sectionPlainText({ title: Club.Label.error, text: "エラーが発生しました。" })],
           })
           .catch((error) => {
             console.error({ error });

--- a/src/commands/newClub.ts
+++ b/src/commands/newClub.ts
@@ -232,7 +232,7 @@ export const useNewClubCommand = (app: App, approvalChannelId: string) => {
         .postMessage({
           token: client.token,
           channel: approvalChannelId,
-          text: `<#${clubChannelId}>が承認されました<:tada:>`,
+          text: `<#${clubChannelId}>が承認されました:tada:`,
         })
         .catch((error) => {
           console.error({ error });

--- a/src/commands/newClub.ts
+++ b/src/commands/newClub.ts
@@ -180,7 +180,7 @@ export const useNewClubCommand = (app: App, approvalChannelId: string) => {
       ack();
 
       const clubChannelId = values.approval_input.approval.selected_option.value as string;
-      const authorizer = body.user;
+      const authorizer = await slack.user.getById(body.user.id);
 
       /* 16. シートの承認APIをコール */
       const response = await gas.api.callApproveClub({
@@ -189,9 +189,10 @@ export const useNewClubCommand = (app: App, approvalChannelId: string) => {
         },
         authorizer: {
           slackId: authorizer.id,
-          name: authorizer.name,
+          name: authorizer.real_name,
         },
       });
+
       if (!response.success) {
         await client.chat
           .postMessage({

--- a/src/types/Messages.ts
+++ b/src/types/Messages.ts
@@ -47,23 +47,6 @@ export interface ModalArg {
   submit: string;
 }
 
-export interface CallNewClubArg {
-  club: {
-    name: string;
-    description: string;
-    budgetUse: string;
-    kibelaUrl: string;
-    channelId: string;
-  };
-  captain: {
-    slackId: string;
-    name: string;
-  };
-  members: {
-    slackId: string;
-    name: string;
-  }[];
-}
 export interface Option {
   text: string;
   value: string;
@@ -83,3 +66,31 @@ export type SectionArgType =
       type: string;
       text: string;
     }[];
+
+export interface CallNewClubArg {
+  club: {
+    name: string;
+    description: string;
+    budgetUse: string;
+    kibelaUrl: string;
+    channelId: string;
+  };
+  captain: {
+    slackId: string;
+    name: string;
+  };
+  members: {
+    slackId: string;
+    name: string;
+  }[];
+}
+
+export interface CallApproveClubArgs {
+  club: {
+    channelId: string;
+  };
+  authorizer: {
+    slackId: string;
+    name: string;
+  };
+}


### PR DESCRIPTION
**_What I did / 技術的変更点概要_**
- 以下を結合
  - スプレッドシートの承認カラムのセルを有効化
    - [失敗時] Slackで承認者宛にDMでエラーメッセージ
  - Kibela記事のフォルダ配置(`部活動/公認`配下に)
  - Kibelaグループに部員を加入
  - Slackの以下のチャンネルに通知
    - 部活チャンネル
    - 承認チャンネル

**_Review Point / レビューしてほしい内容_**

**_Test result & Test points / テスト結果とテスト項目_**

1. 任意のSlackチャンネルにて`/invite`でclub-managerを参加させる
1. Kibelaに部活案内記事作成
  - 部活グループを作成
    - 部活グループと案内記事の紐付け (しないとAPIでグループが取れなくなる)
- [x] 任意のSlackチャンネルにて`/new-club`で創部申請
  - [部活動名]: Kibelaの記事フォルダ名
  - [活動内容], [部費の使用目的]: 任意の文字列
  - [部活チャンネル]: 1 で使用したチャンネルを選択
  - [部長名], [初期メンバー]: 任意のユーザー
  - [部活動紹介記事のKibelaのURL]: 2 で作成した記事のURL
- [x] スプレッドシート上で当該の部活のレコードが作成される (承認カラムはFALSE)
- [x] 承認チャンネルにて↑で投稿されたメッセージにある[承認]ボタンを押下時モーダルが表示される
  - [x] モーダル内に部活チャンネル情報が表示される
- [x] モーダル内の承認ボタンが押せる
- スプレッドシートでの操作
  - [x] 当該の部活のレコードの承認カラムがTRUEになる
  - [x]  当該の部活のシートが作成されている

↑ここまで前PRで動作確認済

- Kibelaでの操作
  - [x] 部活動紹介記事が 部活動/公認 フォルダ内の当該の部活動名フォルダに移動している
  - [x] 当該のグループに部員となるユーザーが参加している
- Slackでの通知
  - [x] 承認チャンネルにて当該の部活が承認された旨を通知
  - [x] 部活チャンネルにて当該の部活が承認された旨を通知
  - [ ] #notifications で通知(別PR)

**_Additional context / 追記・備考_**

Add any other context about the problem here.
