### PR TITLE
mainで`trigger_id` expiredと出て入部処理が落ちる問題の修正

### DIFF
--- a/src/commands/newClub.ts
+++ b/src/commands/newClub.ts
@@ -26,7 +26,7 @@ export const enableNewClubCommand = (app: App, approvalChannelId: string) => {
       },
       client,
     }) => {
-      ack();
+      await ack();
 
       const memberIds = values.member_name.member.selected_users as string[];
       const members = await Promise.all(
@@ -74,8 +74,6 @@ export const enableNewClubCommand = (app: App, approvalChannelId: string) => {
         text: `*<@${member}>*`,
       }));
 
-      console.log("response?.club?.id", response?.club?.id);
-
       const buttons: ButtonArg[] = [
         {
           text: "却下",
@@ -115,7 +113,7 @@ export const enableNewClubCommand = (app: App, approvalChannelId: string) => {
 
   // 却下理由入力モーダル表示
   app.action("reject_modal", async ({ ack, client, body, context }) => {
-    ack();
+    await ack();
 
     openModal({
       client,
@@ -138,7 +136,7 @@ export const enableNewClubCommand = (app: App, approvalChannelId: string) => {
       client,
       context,
     }: SlackActionMiddlewareArgs<InteractiveMessage<ButtonClick>> & AllMiddlewareArgs) => {
-      ack();
+      await ack();
 
       const [channelId, id] = payload.value.split(",");
 
@@ -164,7 +162,7 @@ export const enableNewClubCommand = (app: App, approvalChannelId: string) => {
       client,
       body,
     }) => {
-      ack();
+      await ack();
 
       const id = values.approval_input.approval.selected_option.value as string;
       const authorizer = await slack.user.getById(body.user.id);
@@ -180,8 +178,6 @@ export const enableNewClubCommand = (app: App, approvalChannelId: string) => {
       });
 
       const { success, club } = response;
-
-      console.log(JSON.stringify(response, null, 2));
 
       if (!success || !club || !club.name || /*! club.kibelaUrl || */ !club.members || !club.channelId) {
         await client.chat

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,9 @@ export const app = new App({
   appToken: Config.Slack.APP_TOKEN,
   token: Config.Slack.BOT_TOKEN,
   signingSecret: Config.Slack.SIGNING_SECRET,
+  processBeforeResponse:
+    Config.General.APP_ENV === Config.General.APP_ENV_TYPE.DEV ||
+    Config.General.APP_ENV === Config.General.APP_ENV_TYPE.PRD,
 });
 
 app.error((err) => {

--- a/src/shortcuts/joinClub.ts
+++ b/src/shortcuts/joinClub.ts
@@ -13,7 +13,7 @@ export const enableJoinClubShortcut = (app: App, approvalChannelId: string) => {
   app.shortcut(
     "open_join_club_modal",
     async ({ ack, body, client, context: { botToken } }: SlackShortcutMiddlewareArgs & AllMiddlewareArgs) => {
-      ack();
+      await ack();
 
       const response = await gas.api.callNewJoinClub();
       if (!response.success) {
@@ -70,7 +70,7 @@ export const enableJoinClubShortcut = (app: App, approvalChannelId: string) => {
         user: { id: slackUserId },
       },
     }) => {
-      ack();
+      await ack();
 
       const { value: clubRecordId }: { value: string } = values.join_input.join.selected_option;
 

--- a/src/shortcuts/newClub.ts
+++ b/src/shortcuts/newClub.ts
@@ -5,7 +5,7 @@ import { inputClubModal } from "../blocks/inputClub";
 
 export const enableNewClubShortcut = (app: App) => {
   app.shortcut("open_new_club_modal", async ({ ack, body, client, context }) => {
-    ack();
+    await ack();
 
     openModal({
       client,


### PR DESCRIPTION
**_What I did / 技術的変更点概要_**
- ack()をawaitするようにした
  - これをしないとlocalでも落ちることを確認済
- dev以上の環境下でprocessBeforeResponseが有効になるようにした
  - FaaSの場合、ackレスポンスが返るとハンドラが閉じられる為, らしい


**_Review Point / レビューしてほしい内容_**

**_Test result & Test points / テスト結果とテスト項目_**

- [ ] 別のlocal環境下でも各動作(創部/入部)が全て動くかどうか
- [ ] ...

**_Additional context / 追記・備考_**

Add any other context about the problem here.
